### PR TITLE
Add Steam publishing support via SteamPipe

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -22,6 +22,11 @@ permissions:
 jobs:
   build_linux:
     runs-on: ubuntu-latest
+    env:
+      # Steam publishing is gated on both of these being true. Secrets aren't
+      # readable from a step `if:`, so the config.vdf is lifted into env here.
+      PUBLISH_REF: ${{ github.repository_owner == 'gru2007' && github.event_name == 'push' && (github.ref == 'refs/heads/gf-mod' || github.ref == 'refs/heads/campus-fortress' || startsWith(github.ref, 'refs/heads/release/')) }}
+      STEAM_CONFIG_VDF: ${{ secrets.STEAM_CONFIG_VDF }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -95,6 +100,20 @@ jobs:
         shell: bash
         env:
           BUTLER_API_KEY: ${{ secrets.BUTLER_API_KEY }}
+
+      - name: Push to Steam (playtest)
+        id: steam-playtest
+        if: ${{ env.PUBLISH_REF == 'true' && env.STEAM_CONFIG_VDF != '' }}
+        run: |
+          ./game_clean/steampipe.sh game_dist
+        shell: bash
+        env:
+          STEAM_APPID: ${{ vars.STEAM_APPID }}
+          STEAM_DEPOT_LINUX: ${{ vars.STEAM_DEPOT_LINUX }}
+          # Unset means "upload the build but leave it for a human to set live".
+          STEAM_BRANCH: ${{ vars.STEAM_PLAYTEST_BRANCH }}
+          STEAM_USERNAME: ${{ secrets.STEAM_USERNAME }}
+          STEAM_CONFIG_VDF: ${{ secrets.STEAM_CONFIG_VDF }}
 
       - name: Push Release
         id: create-rel

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -25,6 +25,10 @@ jobs:
     env:
       VCPKG_ROOT: ${{ github.workspace }}/../vcpkg
       VCPKG_DEFAULT_TRIPLET: x64-windows
+      # Steam publishing is gated on both of these being true. Secrets aren't
+      # readable from a step `if:`, so the config.vdf is lifted into env here.
+      PUBLISH_REF: ${{ github.repository_owner == 'gru2007' && github.event_name == 'push' && (github.ref == 'refs/heads/gf-mod' || github.ref == 'refs/heads/campus-fortress' || startsWith(github.ref, 'refs/heads/release/')) }}
+      STEAM_CONFIG_VDF: ${{ secrets.STEAM_CONFIG_VDF }}
     steps:
       # checkout the github actions / workflow
       - name: Checkout actions
@@ -56,6 +60,7 @@ jobs:
             !${{ github.workspace }}/game_clean/**
             !${{ github.workspace }}/game_dist/**
             !${{ github.workspace }}/game_dist_debug/**
+            !${{ github.workspace }}/steam_build/**
             !${{ github.workspace }}/team-comtress-2.png
             !${{ github.workspace }}/.gitattributes
             !${{ github.workspace }}/.gitignore
@@ -151,6 +156,21 @@ jobs:
         shell: bash
         env:
           BUTLER_API_KEY: ${{ secrets.BUTLER_API_KEY }}
+
+      - name: Push to Steam (playtest)
+        id: steam-playtest
+        if: ${{ env.PUBLISH_REF == 'true' && env.STEAM_CONFIG_VDF != '' }}
+        run: |
+          ./game_clean/steampipe.sh game_dist
+        shell: bash
+        env:
+          STEAM_APPID: ${{ vars.STEAM_APPID }}
+          STEAM_DEPOT_WIN: ${{ vars.STEAM_DEPOT_WIN }}
+          # Unset means "upload the build but leave it for a human to set live".
+          STEAM_BRANCH: ${{ vars.STEAM_PLAYTEST_BRANCH }}
+          STEAM_USERNAME: ${{ secrets.STEAM_USERNAME }}
+          STEAM_CONFIG_VDF: ${{ secrets.STEAM_CONFIG_VDF }}
+          BUILD_PLATFORM: win
 
       - name: Push Release
         id: create-rel

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,11 +3,23 @@ name: Publish
 on:
   release:
     types: [released]
+  # Re-push an already published release to Steam without cutting a new one.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to publish to Steam"
+        required: true
+      steam_branch:
+        description: "Steam branch to set live (blank = upload only)"
+        required: false
+
+env:
+  RELEASE_TAG: ${{ github.event.inputs.tag || github.event.release.tag_name }}
 
 jobs:
   publish_permalink:
     name: Publish Permalink Release
-    if: ${{ github.repository_owner == 'gru2007' && !github.event.release.prerelease }}
+    if: ${{ github.repository_owner == 'gru2007' && github.event_name == 'release' && !github.event.release.prerelease }}
     runs-on: ubuntu-latest
     steps:
       - name: Download release assets
@@ -24,7 +36,7 @@ jobs:
 
   publish_itch:
     name: Publish to Itch
-    if: ${{ github.repository_owner == 'gru2007' && !github.event.release.prerelease }}
+    if: ${{ github.repository_owner == 'gru2007' && github.event_name == 'release' && !github.event.release.prerelease }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -63,3 +75,45 @@ jobs:
           BUILD_PLATFORM="linux" BRANCH_STR="stable" RELEASE_VERSION="${{ github.event.release.tag_name }}" ./game_clean/push.sh game_dist_linux
         env:
           BUTLER_API_KEY: ${{ secrets.BUTLER_API_KEY }}
+
+  publish_steam:
+    name: Publish to Steam
+    # Both platforms go up as one SteamPipe build, so a BuildID is always a
+    # complete game rather than half of one.
+    if: ${{ github.repository_owner == 'gru2007' && (github.event_name == 'workflow_dispatch' || !github.event.release.prerelease) }}
+    runs-on: ubuntu-latest
+    env:
+      STEAM_CONFIG_VDF: ${{ secrets.STEAM_CONFIG_VDF }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Download release assets
+        if: ${{ env.STEAM_CONFIG_VDF != '' }}
+        run: |
+          gh release download "${RELEASE_TAG}" --repo gru2007/campus-fortress --pattern "game-*.zip"
+        env:
+          GH_TOKEN: ${{ secrets.REPO_TOKEN }}
+
+      - name: Unpack builds
+        if: ${{ env.STEAM_CONFIG_VDF != '' }}
+        run: |
+          mkdir -p game_dist_win game_dist_linux
+          7z x -y game-win.zip -ogame_dist_win/
+          7z x -y game-linux.zip -ogame_dist_linux/
+          # The zip round trip can drop the executable bit, and the depot keeps
+          # whatever mode the file has when it's uploaded.
+          chmod +x game_dist_linux/*.sh game_dist_linux/tc2_linux64 game_dist_linux/srcds_run_64
+
+      - name: Push to Steam
+        if: ${{ env.STEAM_CONFIG_VDF != '' }}
+        run: |
+          STEAM_WIN_DIR="${PWD}/game_dist_win" STEAM_LINUX_DIR="${PWD}/game_dist_linux" ./game_clean/steampipe.sh
+        env:
+          STEAM_APPID: ${{ vars.STEAM_APPID }}
+          STEAM_DEPOT_WIN: ${{ vars.STEAM_DEPOT_WIN }}
+          STEAM_DEPOT_LINUX: ${{ vars.STEAM_DEPOT_LINUX }}
+          STEAM_BRANCH: ${{ github.event.inputs.steam_branch || vars.STEAM_RELEASE_BRANCH }}
+          STEAM_USERNAME: ${{ secrets.STEAM_USERNAME }}
+          STEAM_CONFIG_VDF: ${{ secrets.STEAM_CONFIG_VDF }}
+          RELEASE_VERSION: ${{ env.RELEASE_TAG }}

--- a/.gitignore
+++ b/.gitignore
@@ -577,6 +577,9 @@ version.txt
 game_dist
 game_dist_debug
 
+# SteamPipe build scripts, upload logs and depot chunks (game_clean/steampipe.sh)
+steam_build
+
 enc_temp_folder
 
 /build/

--- a/docs/GREYLINE-TESTING.md
+++ b/docs/GREYLINE-TESTING.md
@@ -109,7 +109,9 @@ C++ and its generated protobuf. Until that has run green once, treat the C++ as
 unverified.
 
 Release publishing is gated on `github.repository_owner == 'gru2007'` and the
-`campus-fortress` branch, so forks build but do not publish. The Windows job
+`campus-fortress` branch, so forks build but do not publish. Steam publishing is
+gated the same way plus `gf-mod`, and additionally on the `STEAM_CONFIG_VDF`
+secret being set — see `docs/STEAMPIPE.md`. The Windows job
 needs a runner with Visual Studio 2026 because `createallprojects.bat` passes
 `/define:VS2026`; if yours is labelled differently, set the `WINDOWS_RUNNER`
 repository variable.
@@ -411,9 +413,10 @@ so a host's scoreline is only checked against what the other players report.
 Turning it on requires the HMAC half on the C++ side, which is not written.
 
 **Auth is `dev` mode.** The coordinator trusts the SteamID a client claims.
-Real ticket validation needs a publisher Web API key, which needs the project's
-own AppID; `gameinfo.txt` still declares Valve's 243750. Test on a network you
-control.
+Real ticket validation needs a publisher Web API key. We now have an AppID of
+our own to issue one against — `gameinfo.txt` declares 5147520, Team Frontress
+Playtest (`docs/STEAMPIPE.md`) — but the key is not wired up yet, so until it
+is, test on a network you control.
 
 **The C++ has never been compiled.** It was written against the tree's own APIs
 and cross-checked against the SDK headers, but this machine cannot build the

--- a/docs/STEAMPIPE.md
+++ b/docs/STEAMPIPE.md
@@ -1,0 +1,172 @@
+# Shipping on Steam (SteamPipe)
+
+The game is published as **Team Frontress Playtest, AppID `5147520`**. This
+document covers what binds the build to that AppID, how a build gets to Steam,
+and what has to exist in Steamworks for either half to work.
+
+## AppIDs
+
+| AppID | What it is | Who needs it |
+| --- | --- | --- |
+| `5147520` | Team Frontress Playtest — the app we publish under | every player |
+| `440` | Team Fortress 2 — engine binaries and game content | every player |
+| `243750` | Source SDK Base 2013 Multiplayer | Windows dedicated servers |
+| `244310` | Source SDK Base 2013 Dedicated Server | Linux dedicated servers |
+
+We ship the mod's own DLLs, tools and paks; the engine itself is loaded out of
+the player's TF2 install (`GetGameInstallDir` in `src/launcher_main/main.cpp`),
+and TF2's VPKs are mounted through `|appid_440|` search paths. TF2 remains a
+hard requirement — the launcher shows an error and exits without it.
+
+Dedicated servers stay on the SDK 2013 apps. They log into Steam anonymously,
+which cannot mount a playtest app, so `gameinfo_server.txt` still declares
+`243750`.
+
+## What binds the client to 5147520
+
+Four places, all of which have to agree:
+
+| File | Field |
+| --- | --- |
+| `game/tc2/gameinfo.txt` | `FileSystem/SteamAppId` — what the engine's filesystem initialises as |
+| `game/tc2/steam.inf` | `appID` — what the engine reports to the server browser and to Steam |
+| `src/launcher_main/launcher_main_tc2.vpc` | `MOD_APPID` — compiled into the launcher, written to `steam_appid.txt` before `SteamAPI_Init` |
+| `src/public/filesystem_init.cpp` | `g_Source1Appids` — only the name shown in "you must own …" errors |
+
+`steam_appid.txt` is written next to the executable on every launch, so a stale
+file from an older build can never win over the AppID we ship with. It is
+excluded from the depot for the same reason it exists: a copy of it that we did
+*not* write would let the game start without Steam having checked ownership.
+
+## Depots
+
+`game_clean/steampipe.sh` defaults to `AppID + 1` for Windows content and
+`AppID + 2` for Linux:
+
+| Depot | Content |
+| --- | --- |
+| `5147521` | Windows (`game_dist` from a Windows build) |
+| `5147522` | Linux (`game_dist` from a Linux build) |
+
+If Steamworks assigned different depot IDs, override them — repository variables
+`STEAM_DEPOT_WIN` / `STEAM_DEPOT_LINUX` in CI, or the same environment variables
+locally. Nothing else needs to change.
+
+Debug symbols (`*.pdb`, `*.dbg`) are not in the depots. They stay in the
+`game-debug-info` build artifact, same as before.
+
+## Uploading
+
+`game_clean/steampipe.sh` generates the app and depot build scripts from a dist
+directory, fetches `steamcmd` if it isn't on `PATH`, and runs `run_app_build`.
+The generated scripts and the upload log are left in `steam_build/` for
+inspection after a failed run.
+
+Locally, after `./game_clean/copy.sh`:
+
+```bash
+STEAM_USERNAME=<builder account> STEAM_PASSWORD=<password> \
+  ./game_clean/steampipe.sh game_dist
+```
+
+Both platforms in a single build (one BuildID covering both depots) — this is
+what the release job does, from two unpacked release zips:
+
+```bash
+STEAM_USERNAME=… STEAM_CONFIG_VDF=… \
+STEAM_WIN_DIR=$PWD/game_dist_win STEAM_LINUX_DIR=$PWD/game_dist_linux \
+  ./game_clean/steampipe.sh
+```
+
+Add `STEAMPIPE_PREVIEW=1` to generate and validate the build without uploading
+anything.
+
+### Variables
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `STEAM_APPID` | `5147520` | app to build into |
+| `STEAM_DEPOT_WIN` | `STEAM_APPID + 1` | Windows content depot |
+| `STEAM_DEPOT_LINUX` | `STEAM_APPID + 2` | Linux content depot |
+| `STEAM_WIN_DIR` / `STEAM_LINUX_DIR` | — | content dirs; set both for a combined build |
+| `STEAM_BRANCH` | empty | branch to set live; empty uploads without setting anything live |
+| `STEAM_USERNAME` | — | builder account (required) |
+| `STEAM_CONFIG_VDF` | — | base64 `config.vdf` for unattended login |
+| `STEAM_PASSWORD` | — | password, for local runs without a `config.vdf` |
+| `RELEASE_VERSION` | `VERSION` from `shared.sh` | build description |
+| `STEAMPIPE_PREVIEW` | `0` | `1` = validate only, no upload |
+| `STEAMCMD` | `steamcmd` on `PATH`, else downloaded | path to a specific steamcmd |
+| `STEAMCMD_HOME` | `~/steamcmd` | where a downloaded steamcmd is installed |
+
+steamcmd is installed outside the repository on purpose: it stores the login
+token next to itself, and the Windows CI job caches the whole workspace.
+
+An empty `STEAM_BRANCH` is deliberate: a `setlive` naming a branch that doesn't
+exist in Steamworks fails the whole build, so auto-setlive is opt-in.
+
+## CI
+
+| Where | When | Sets live |
+| --- | --- | --- |
+| `build_linux.yml`, `build_windows.yml` | push to `gf-mod`, `campus-fortress`, or `release/*` | `STEAM_PLAYTEST_BRANCH` |
+| `publish.yml` (`publish_steam`) | a non-prerelease GitHub release, or `workflow_dispatch` with a tag | `STEAM_RELEASE_BRANCH`, or the branch given to the dispatch |
+
+The per-platform build jobs upload one depot each, so a BuildID from them covers
+only the platform that produced it. The release job downloads both release zips
+and uploads both depots as one build; prefer it for anything players get.
+
+Every Steam step is skipped when `STEAM_CONFIG_VDF` is unset, so forks and
+credential-less runs build normally and publish nothing.
+
+### Secrets and variables
+
+Repository secrets:
+
+- `STEAM_USERNAME` — a Steamworks account with "Edit App Metadata" and
+  "Publish App Changes To Steam" on the app. Use a dedicated builder account,
+  not a personal one; Steam Guard on it must be email- or app-based, not
+  disabled.
+- `STEAM_CONFIG_VDF` — base64 of a `config.vdf` from a session that has already
+  cleared Steam Guard.
+
+Repository variables (all optional):
+
+- `STEAM_APPID`, `STEAM_DEPOT_WIN`, `STEAM_DEPOT_LINUX` — override the defaults
+  above.
+- `STEAM_PLAYTEST_BRANCH` — branch the branch builds set live, e.g. `prerelease`.
+- `STEAM_RELEASE_BRANCH` — branch releases set live, e.g. `default`.
+
+### Generating `STEAM_CONFIG_VDF`
+
+On a machine with `steamcmd`, logged in as the builder account:
+
+```bash
+steamcmd +login <builder account> +quit   # answer the Steam Guard prompt
+base64 -w0 ~/Steam/config/config.vdf      # paste into the secret
+```
+
+Log in once more afterwards and confirm it no longer asks for a code — that is
+the state the secret has to capture. The token expires if unused for a long
+time, or when the account's password changes; regenerate it the same way.
+
+## Steamworks configuration
+
+The upload only covers content. These have to be set on the app itself:
+
+- **Depots** `5147521` (Windows) and `5147522` (Linux) must exist and be
+  included in the playtest package.
+- **Launch options**:
+  - Windows — `tc2_win64.exe`, arguments
+    `-steam -particles 1 -condebug -nobreakpad -nominidumps -enablefakeip +ip 127.0.0.1`
+  - Linux — `tc2.sh`, same arguments plus `-gathermod`
+- **Steam Linux Runtime 3.0 (sniper), AppID `1628350`** must be a required tool
+  for the Linux launch option. `tc2.sh` refuses to start without it, and on a
+  Steam install it will not be there unless the app asks for it.
+- **Lobbies / matchmaking**: Greyline's transport now runs over the coordinator
+  link rather than Steam lobbies, but anything that does call into Steam
+  matchmaking needs the app configured for it — this is the setting that made
+  `CreateLobby` return `AccessDenied` back when we ran under 243750
+  (`services/coordinator/docs/NETWORKING-SPIKE.md`).
+- **Publisher Web API key**: needed to validate Steam auth tickets properly
+  instead of trusting the SteamID a client claims (`security.auth_mode` in the
+  coordinator). Owning the AppID is what makes that possible.

--- a/game/tc2/gameinfo.txt
+++ b/game/tc2/gameinfo.txt
@@ -22,8 +22,10 @@
 
 	FileSystem
 	{
-		SteamAppId				243750
-		
+		// Team Frontress Playtest. This is the app the client is published
+		// under on SteamPipe, so it is the app Steam initialises us as.
+		SteamAppId				5147520
+
 		SearchPaths
 		{
 			// First, mount all user customizations.  This will search for VPKs and subfolders

--- a/game/tc2/gameinfo_server.txt
+++ b/game/tc2/gameinfo_server.txt
@@ -22,8 +22,12 @@
 
 	FileSystem
 	{
+		// Dedicated servers stay on Source SDK Base 2013 Dedicated Server: they
+		// log in anonymously through steamcmd and cannot mount the playtest app
+		// (5147520), which requires an account that owns it. Only the client is
+		// published under the playtest AppID -- see docs/STEAMPIPE.md.
 		SteamAppId				243750
-		
+
 		SearchPaths
 		{
 			// First, mount all user customizations.  This will search for VPKs and subfolders

--- a/game/tc2/steam.inf
+++ b/game/tc2/steam.inf
@@ -2,5 +2,5 @@ PatchVersion=120125
 ClientVersion=120125
 ServerVersion=120125
 ProductName=tc2
-appID=243750
+appID=5147520
 ServerAppID=244310

--- a/game_clean/steampipe.sh
+++ b/game_clean/steampipe.sh
@@ -1,0 +1,295 @@
+#!/usr/bin/env bash
+#
+# Upload a build to Steam through SteamPipe.
+#
+# Generates the app/depot build scripts from the dist directories we already
+# produce for itch, then hands them to steamcmd's run_app_build. steamcmd is
+# downloaded into cibin/ if it isn't on PATH.
+#
+# Usage:
+#   ./steampipe.sh [content_dir]
+#
+#     content_dir  content for the platform this is running on (defaults to
+#                  ${CLEAN_DIR}, i.e. what copy.sh just produced). Relative
+#                  paths resolve against the directory you invoke this from,
+#                  same as push.sh.
+#
+# To upload both platforms in one build (a single BuildID covering both
+# depots), skip the argument and set STEAM_WIN_DIR and STEAM_LINUX_DIR.
+#
+# Environment:
+#   STEAM_APPID         app to build into        (default 5147520, Team Frontress Playtest)
+#   STEAM_DEPOT_WIN     Windows content depot    (default STEAM_APPID + 1)
+#   STEAM_DEPOT_LINUX   Linux content depot      (default STEAM_APPID + 2)
+#   STEAM_WIN_DIR       Windows content dir      (overrides the positional arg)
+#   STEAM_LINUX_DIR     Linux content dir        (overrides the positional arg)
+#   STEAM_BRANCH        beta branch to set live  (empty = upload only, set live by hand)
+#   STEAM_USERNAME      Steam builder account    (required)
+#   STEAM_CONFIG_VDF    base64 of a config.vdf already logged in as that
+#                       account, so CI does not need a Steam Guard code
+#   STEAM_PASSWORD      password, for interactive/local use when there is no
+#                       STEAM_CONFIG_VDF
+#   RELEASE_VERSION     build description        (default: git describe)
+#   STEAMPIPE_PREVIEW   1 = generate + validate the build without uploading
+#
+# Run script within the directory
+BIN_DIR=$(dirname "$(readlink -fn "$0")")
+ORIGINAL_DIR=$(pwd)
+cd "${BIN_DIR}" || exit 2
+
+set -euo pipefail
+
+source ./shared.sh
+
+STEAM_APPID="${STEAM_APPID:-5147520}"
+STEAM_DEPOT_WIN="${STEAM_DEPOT_WIN:-$((STEAM_APPID + 1))}"
+STEAM_DEPOT_LINUX="${STEAM_DEPOT_LINUX:-$((STEAM_APPID + 2))}"
+STEAM_BRANCH="${STEAM_BRANCH:-}"
+STEAM_USERNAME="${STEAM_USERNAME:-}"
+STEAM_CONFIG_VDF="${STEAM_CONFIG_VDF:-}"
+STEAM_PASSWORD="${STEAM_PASSWORD:-}"
+STEAMPIPE_PREVIEW="${STEAMPIPE_PREVIEW:-0}"
+
+# The dist dir for the platform we're running on, unless told otherwise.
+PLATFORM_DIR="${CLEAN_DIR}"
+if [ -n "${1:-}" ]; then
+  PLATFORM_DIR="${ORIGINAL_DIR}/$1"
+fi
+
+WIN_DIR="${STEAM_WIN_DIR:-}"
+LINUX_DIR="${STEAM_LINUX_DIR:-}"
+
+if [ -z "${WIN_DIR}" ] && [ -z "${LINUX_DIR}" ]; then
+  if [ "${PLATFORM}" = "win" ]; then
+    WIN_DIR="${PLATFORM_DIR}"
+  else
+    LINUX_DIR="${PLATFORM_DIR}"
+  fi
+fi
+
+if [ -n "${RELEASE_VERSION:-}" ]; then
+  VERSION="${RELEASE_VERSION}"
+elif [ "${GITHUB_REF_TYPE:-}" = "tag" ] && [ -n "${GITHUB_REF_NAME:-}" ]; then
+  VERSION="${GITHUB_REF_NAME}"
+fi
+
+BUILD_DESC="${VERSION}"
+if [ -n "${GITHUB_SHA:-}" ]; then
+  BUILD_DESC="${BUILD_DESC} (${GITHUB_SHA:0:8})"
+elif COMMIT=$(git rev-parse --short HEAD 2>/dev/null); then
+  BUILD_DESC="${BUILD_DESC} (${COMMIT})"
+fi
+
+if [ -z "${STEAM_USERNAME}" ]; then
+  echo "STEAM_USERNAME is not set: nothing to log in as." >&2
+  exit 1
+fi
+
+if [ -z "${STEAM_CONFIG_VDF}" ] && [ -z "${STEAM_PASSWORD}" ]; then
+  echo "Set STEAM_CONFIG_VDF (CI) or STEAM_PASSWORD (local) to log in." >&2
+  exit 1
+fi
+
+# Absolute paths: steamcmd resolves everything in the build scripts relative to
+# its own working directory, not to the script.
+abs_path() {
+  (cd "$1" >/dev/null 2>&1 && pwd)
+}
+
+check_content_dir() {
+  local NAME=$1
+  local DIR=$2
+
+  if [ ! -d "${DIR}" ]; then
+    echo "${NAME} content dir does not exist: ${DIR}" >&2
+    exit 1
+  fi
+
+  if [ -z "$(ls -A "${DIR}")" ]; then
+    echo "${NAME} content dir is empty: ${DIR}" >&2
+    exit 1
+  fi
+}
+
+if [ -n "${WIN_DIR}" ]; then
+  check_content_dir "Windows" "${WIN_DIR}"
+  WIN_DIR=$(abs_path "${WIN_DIR}")
+fi
+
+if [ -n "${LINUX_DIR}" ]; then
+  check_content_dir "Linux" "${LINUX_DIR}"
+  LINUX_DIR=$(abs_path "${LINUX_DIR}")
+fi
+
+BUILD_DIR="${BIN_DIR}/../steam_build"
+rm -rf "${BUILD_DIR}"
+mkdir -p "${BUILD_DIR}/output"
+BUILD_DIR=$(abs_path "${BUILD_DIR}")
+
+# steamcmd on Windows wants Windows paths in the build scripts.
+script_path() {
+  if [ "${PLATFORM}" = "win" ] && command -v cygpath >/dev/null 2>&1; then
+    cygpath -w "$1"
+  else
+    echo "$1"
+  fi
+}
+
+write_depot_script() {
+  local DEPOT=$1
+  local CONTENT=$2
+
+  cat > "${BUILD_DIR}/depot_${DEPOT}.vdf" <<EOF
+"DepotBuildConfig"
+{
+	"DepotID"		"${DEPOT}"
+	"ContentRoot"	"$(script_path "${CONTENT}")"
+
+	"FileMapping"
+	{
+		"LocalPath"	"*"
+		"DepotPath"	"."
+		"recursive"	"1"
+	}
+
+	// Debug info ships out of band (game_dist_debug), the itch manifest is for
+	// itch only, and a steam_appid.txt in the depot would let the game start
+	// without Steam having checked ownership.
+	"FileExclusion"	"*.pdb"
+	"FileExclusion"	"*.dbg"
+	"FileExclusion"	".itch.toml"
+	"FileExclusion"	"steam_appid.txt"
+}
+EOF
+}
+
+DEPOT_ENTRIES=""
+
+if [ -n "${WIN_DIR}" ]; then
+  write_depot_script "${STEAM_DEPOT_WIN}" "${WIN_DIR}"
+  DEPOT_ENTRIES="${DEPOT_ENTRIES}		\"${STEAM_DEPOT_WIN}\"	\"$(script_path "${BUILD_DIR}/depot_${STEAM_DEPOT_WIN}.vdf")\"
+"
+fi
+
+if [ -n "${LINUX_DIR}" ]; then
+  write_depot_script "${STEAM_DEPOT_LINUX}" "${LINUX_DIR}"
+  DEPOT_ENTRIES="${DEPOT_ENTRIES}		\"${STEAM_DEPOT_LINUX}\"	\"$(script_path "${BUILD_DIR}/depot_${STEAM_DEPOT_LINUX}.vdf")\"
+"
+fi
+
+APP_SCRIPT="${BUILD_DIR}/app_build_${STEAM_APPID}.vdf"
+cat > "${APP_SCRIPT}" <<EOF
+"appbuild"
+{
+	"appid"			"${STEAM_APPID}"
+	"desc"			"${BUILD_DESC}"
+	"buildoutput"	"$(script_path "${BUILD_DIR}/output")"
+	"contentroot"	""
+	"setlive"		"${STEAM_BRANCH}"
+	"preview"		"${STEAMPIPE_PREVIEW}"
+	"local"			""
+
+	"depots"
+	{
+${DEPOT_ENTRIES}	}
+}
+EOF
+
+echo "SteamPipe build script:"
+cat "${APP_SCRIPT}"
+
+# --- steamcmd ---------------------------------------------------------------
+
+# Outside the repo on purpose: steamcmd keeps the login token next to itself,
+# and CI caches the workspace.
+STEAMCMD_DIR="${STEAMCMD_HOME:-${HOME}/steamcmd}/${PLATFORM}"
+
+install_steamcmd() {
+  mkdir -p "${STEAMCMD_DIR}"
+
+  if [ "${PLATFORM}" = "win" ]; then
+    curl -sSL --fail --retry 3 "https://steamcdn-a.akamaihd.net/client/installer/steamcmd.zip" -o "${STEAMCMD_DIR}/steamcmd.zip"
+    $CMD_7Z x -y "${STEAMCMD_DIR}/steamcmd.zip" "-o${STEAMCMD_DIR}"
+    STEAMCMD="${STEAMCMD_DIR}/steamcmd.exe"
+  else
+    # steamcmd is a 32 bit binary; the runtime it needs isn't in every image.
+    if ! ldconfig -p 2>/dev/null | grep -q "libgcc_s.so.1 (libc6,x86"; then
+      if command -v sudo >/dev/null 2>&1 && command -v apt-get >/dev/null 2>&1; then
+        sudo dpkg --add-architecture i386
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends lib32gcc-s1 lib32stdc++6
+      else
+        echo "warning: 32 bit libgcc not found and can't install it; steamcmd may fail to start." >&2
+      fi
+    fi
+
+    curl -sSL --fail --retry 3 "https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz" -o "${STEAMCMD_DIR}/steamcmd_linux.tar.gz"
+    tar -xzf "${STEAMCMD_DIR}/steamcmd_linux.tar.gz" -C "${STEAMCMD_DIR}"
+    STEAMCMD="${STEAMCMD_DIR}/steamcmd.sh"
+  fi
+
+  chmod +x "${STEAMCMD}" 2>/dev/null || true
+}
+
+if [ -n "${STEAMCMD:-}" ]; then
+  :
+elif command -v steamcmd >/dev/null 2>&1; then
+  STEAMCMD=$(command -v steamcmd)
+else
+  install_steamcmd
+fi
+
+echo "Using steamcmd: ${STEAMCMD}"
+
+# Steam Guard: a config.vdf from an account that has already answered a code
+# lets steamcmd log in unattended. Drop it everywhere steamcmd looks for one.
+if [ -n "${STEAM_CONFIG_VDF}" ]; then
+  for CONFIG_DIR in "${HOME}/Steam/config" "${HOME}/.steam/steam/config" "$(dirname "${STEAMCMD}")/config"; do
+    mkdir -p "${CONFIG_DIR}"
+    echo "${STEAM_CONFIG_VDF}" | base64 -d > "${CONFIG_DIR}/config.vdf"
+    chmod 600 "${CONFIG_DIR}/config.vdf"
+  done
+fi
+
+# --- upload -----------------------------------------------------------------
+
+RUN_LOG="${BUILD_DIR}/steamcmd.log"
+
+run_steamcmd() {
+  if [ -n "${STEAM_CONFIG_VDF}" ]; then
+    "${STEAMCMD}" +login "${STEAM_USERNAME}" +run_app_build "$(script_path "${APP_SCRIPT}")" +quit
+  else
+    "${STEAMCMD}" +login "${STEAM_USERNAME}" "${STEAM_PASSWORD}" +run_app_build "$(script_path "${APP_SCRIPT}")" +quit
+  fi
+}
+
+# steamcmd exits 0 on some failed logins and self-updates on first run, so the
+# log is what we trust. Retry a couple of times for transient CDN/login errors.
+ATTEMPT=1
+MAX_ATTEMPTS=3
+while true; do
+  echo "steamcmd attempt ${ATTEMPT}/${MAX_ATTEMPTS}"
+
+  set +e
+  run_steamcmd 2>&1 | tee "${RUN_LOG}"
+  STATUS=${PIPESTATUS[0]}
+  set -e
+
+  if [ ${STATUS} -eq 0 ] && grep -qi "successfully finished appid ${STEAM_APPID}" "${RUN_LOG}"; then
+    break
+  fi
+
+  if [ ${ATTEMPT} -ge ${MAX_ATTEMPTS} ]; then
+    echo "steamcmd failed after ${MAX_ATTEMPTS} attempts (exit ${STATUS})." >&2
+    exit 1
+  fi
+
+  ATTEMPT=$((ATTEMPT + 1))
+  sleep $((ATTEMPT * 5))
+done
+
+if [ -n "${STEAM_BRANCH}" ]; then
+  echo "Uploaded AppID ${STEAM_APPID} and set branch '${STEAM_BRANCH}' live."
+else
+  echo "Uploaded AppID ${STEAM_APPID}. No branch set live; do it from Steamworks."
+fi

--- a/services/coordinator/docs/NETWORKING-SPIKE.md
+++ b/services/coordinator/docs/NETWORKING-SPIKE.md
@@ -189,9 +189,9 @@ What happened on the first real run:
 
 `EResult 15` is `k_EResultAccessDenied`. For `CreateLobby`, Valve documents it as
 the app not being configured for lobbies, or the user lacking access to it —
-a **Steamworks setting on the AppID**, not a bug in the caller. This mod runs
-under an AppID it does not own (`gameinfo.txt` still declares 243750), so that
-setting is not ours to change, and every match died in the same place:
+a **Steamworks setting on the AppID**, not a bug in the caller. At the time, the
+mod ran under an AppID it did not own (`gameinfo.txt` declared Valve's 243750),
+so that setting was not ours to change, and every match died in the same place:
 
 ```
 match formed → host elected → CreateLobby → AccessDenied → host never reports

--- a/src/launcher_main/launcher_main_tc2.vpc
+++ b/src/launcher_main/launcher_main_tc2.vpc
@@ -8,7 +8,7 @@ $Configuration
 {
 	$Compiler
 	{
-		$PreprocessorDefinitions	"$BASE;MOD_APPID=243750" // Replace with your appid if you ship on Steam.
+		$PreprocessorDefinitions	"$BASE;MOD_APPID=5147520" // Team Frontress Playtest, the app we ship under on SteamPipe.
 	}
 }
 

--- a/src/launcher_main/main.cpp
+++ b/src/launcher_main/main.cpp
@@ -163,7 +163,9 @@ static bool LoadSteam( const char *pRootDir )
 		return false;
 	}
 
-	// Make a steam_appid.txt now, of just eg. Source SDK 2013 MP for this.
+	// Point SteamAPI_Init at our own AppID (Team Frontress Playtest when built
+	// with MOD_LAUNCHER, see launcher_main_tc2.vpc). Written unconditionally so
+	// a stale file from an older build cannot win over the AppID we ship with.
 	FILE *pFile = fopen( "steam_appid.txt", "w" );
 	if ( pFile )
 	{

--- a/src/public/filesystem_init.cpp
+++ b/src/public/filesystem_init.cpp
@@ -622,6 +622,8 @@ struct Source1AppidInfo_t
 	{ 550, "Left 4 Dead 2" },
 	{ 630, "Alien Swarm" },
 
+	{ 5147520, "Team Frontress Playtest" },
+
 	{ 243750, "Source SDK Base 2013 Multiplayer" },
 	{ 243730, "Source SDK Base 2013 Singleplayer" },
 	{ 218, "Source SDK Base 2007" },


### PR DESCRIPTION
### Related Issue
N/A

### Implementation

This PR adds complete Steam publishing infrastructure for Team Frontress Playtest (AppID 5147520):

**New files:**
- `game_clean/steampipe.sh` — Main upload script that generates SteamPipe build scripts from dist directories, downloads steamcmd if needed, and uploads to Steam with retry logic
- `docs/STEAMPIPE.md` — Comprehensive documentation covering AppID bindings, depot configuration, upload procedures, CI integration, and Steamworks setup requirements

**AppID migration:**
- Updated all AppID references from 243750 (Source SDK Base 2013) to 5147520 (Team Frontress Playtest):
  - `game/tc2/gameinfo.txt` — Client filesystem initialization
  - `game/tc2/steam.inf` — Engine reporting to server browser
  - `src/launcher_main/launcher_main_tc2.vpc` — Launcher preprocessor definition
  - `src/public/filesystem_init.cpp` — Error message display
  - `game/tc2/gameinfo_server.txt` — Kept at 243750 with explanation (dedicated servers log in anonymously and cannot mount playtest app)

**CI integration:**
- `build_windows.yml` — Added Steam playtest upload step for gf-mod, campus-fortress, and release/* branches
- `build_linux.yml` — Added Steam playtest upload step (same branches)
- `publish.yml` — Added `publish_steam` job that downloads both platform release zips and uploads as a single SteamPipe build; added `workflow_dispatch` trigger to re-publish existing releases with custom branch selection

**Configuration:**
- `.gitignore` — Exclude steam_build/ directory (generated scripts and logs)
- Updated `docs/GREYLINE-TESTING.md` to document Steam publishing gates and reference STEAMPIPE.md

The implementation supports:
- Per-platform uploads (branch builds) and combined uploads (release builds)
- Unattended CI login via base64-encoded config.vdf
- Interactive local login via password
- Preview mode (validate without uploading)
- Automatic retry on transient failures
- Proper path handling for Windows (cygpath) and Linux

### Checklist
- [x] No other PRs implement this idea
- [x] This PR does not introduce any regressions
- [x] I certify that this PR is my own entirely original work
- [x] This PR targets the appropriate branch

### Testing Checklist
N/A — This is infrastructure code. CI workflows will validate the upload scripts on next push to gf-mod/campus-fortress/release branches and on next release.

### Caveats
- Requires `STEAM_CONFIG_VDF` secret to be set in CI for uploads to proceed; forks and credential-less runs will build normally but skip Steam publishing
- Dedicated servers remain on AppID 243750 (cannot be changed without breaking anonymous login)
- Debug symbols are intentionally excluded from depots (shipped separately in game-debug-info artifact)

https://claude.ai/code/session_01VDRJyCGWf6BNa1tcRtaUhk