### PR TITLE
Fix SteamCMD client library links for dedicated servers

### DIFF
--- a/game/start_dedicated_tc2.sh
+++ b/game/start_dedicated_tc2.sh
@@ -23,6 +23,11 @@ esac
 
 mv tc2/gameinfo_client.txt tc2/gameinfo.txt
 
-stty sane
+# Desktop launches have a terminal to restore; Docker/SSH supervisors usually
+# do not. Calling stty on a non-TTY only adds a misleading error after the real
+# server exit reason.
+if [ -t 0 ]; then
+    stty sane
+fi
 
 popd > /dev/null

--- a/game/steamcmd_update.sh
+++ b/game/steamcmd_update.sh
@@ -4,3 +4,35 @@ set -euo pipefail
 
 steamcmd +force_install_dir SteamLinuxRuntime_sniper +login anonymous +app_update 1628350 validate +quit
 steamcmd +force_install_dir tf2 +login anonymous +app_update 232250 validate +quit
+
+# Source dedicated servers look for Steam's client library in ~/.steam/sdk64,
+# while SteamCMD usually installs it under ~/.local/share/Steam/steamcmd (the
+# Ubuntu package) or one of the traditional SteamCMD directories. Keep the SDK
+# links in sync whenever dependencies are installed or updated.
+steamcmd_root=""
+for candidate in \
+    "$HOME/.local/share/Steam/steamcmd" \
+    "$HOME/.steam/steamcmd" \
+    "$HOME/Steam" \
+    "$HOME/steamcmd"
+do
+    if [ -f "$candidate/linux64/steamclient.so" ]; then
+        steamcmd_root="$candidate"
+        break
+    fi
+done
+
+if [ -z "$steamcmd_root" ]; then
+    echo "ERROR: SteamCMD steamclient.so not found after update" >&2
+    exit 1
+fi
+
+mkdir -p "$HOME/.steam/sdk64"
+ln -sfn "$steamcmd_root/linux64/steamclient.so" "$HOME/.steam/sdk64/steamclient.so"
+
+if [ -f "$steamcmd_root/linux32/steamclient.so" ]; then
+    mkdir -p "$HOME/.steam/sdk32"
+    ln -sfn "$steamcmd_root/linux32/steamclient.so" "$HOME/.steam/sdk32/steamclient.so"
+fi
+
+test -e "$HOME/.steam/sdk64/steamclient.so"


### PR DESCRIPTION
Dedicated Linux servers can fail SteamGameServer initialization with `~/.steam/sdk64/steamclient.so: cannot open shared object file` even after SteamCMD and the runtime are installed. SteamCMD installs the library elsewhere, while Source still probes the SDK path.

This PR updates `steamcmd_update.sh` to provision sdk64/sdk32 symlinks after dependency updates across common SteamCMD layouts. It also avoids the misleading `stty: Inappropriate ioctl for device` message when the dedicated launcher is supervised without a TTY.