### PR TITLE
Fix headless dedicated runtime path

### DIFF
--- a/game/start_dedicated_tc2.sh
+++ b/game/start_dedicated_tc2.sh
@@ -12,6 +12,21 @@ if [ ! -f bin/linux64/libtinfo.so.5 ]; then
     ln -s /lib/x86_64-linux-gnu/libtinfo.so.6 bin/linux64/libtinfo.so.5
 fi
 
+# Headless dedicated servers must not initialise the desktop Steam client.
+# launcher_main already has a dedicated -nosteamclient path for this, but its
+# legacy POSIX fallback expects the Valve dedicated runtime in ../tf2ds. Our
+# supported layout installs AppID 232250 as ./tf2 (steamcmd_update.sh and the
+# Frontress Docker image both do this), so provide the legacy path as a symlink.
+# This keeps older launcher binaries working while avoiding SteamAPI_Init's
+# dependency on a running Steam desktop client.
+if [ -d "$PWD/tf2" ]; then
+    if [ -L ../tf2ds ]; then
+        ln -sfn "$PWD/tf2" ../tf2ds
+    elif [ ! -e ../tf2ds ]; then
+        ln -s "$PWD/tf2" ../tf2ds
+    fi
+fi
+
 # sv_pure follows the same rule as +ip: a default, not an override. The match
 # config the coordinator execs can still set it either way.
 PURE_DEFAULT=(+sv_pure 1)
@@ -19,7 +34,7 @@ case " $* " in
   *" +sv_pure "*) PURE_DEFAULT=() ;;
 esac
 
-./tc2.sh -console -dedicated -gatherdedi "$@" "${PURE_DEFAULT[@]}"
+./tc2.sh -console -dedicated -nosteamclient -gatherdedi "$@" "${PURE_DEFAULT[@]}"
 
 mv tc2/gameinfo_client.txt tc2/gameinfo.txt
 


### PR DESCRIPTION
The headless dedicated path already supports `-nosteamclient`, but on POSIX launcher_main maps that mode to a legacy sibling `../tf2ds` directory. Our current server layout installs Valve's AppID 232250 content as `./tf2`, so the second launcher invocation fails with `Failed to load the launcher: .../tf2ds/bin/linux64/dedicated_srv.so`.

This changes the supported dedicated launcher script to:

- always use `-nosteamclient` for headless dedicated servers, avoiding the desktop `SteamAPI_Init`/Steam pipe requirement;
- expose the canonical `./tf2` dependency tree at the legacy `../tf2ds` path expected by existing launcher binaries;
- preserve a real existing `../tf2ds` directory, while repairing/replacing symlinks safely.

This is deliberately compatible with the currently published launcher binary, so a server payload can be fixed without first changing/rebuilding launcher_main itself.